### PR TITLE
新增神龙级“破帧”模块并在 hurt() 注入清除无敌帧逻辑

### DIFF
--- a/src/main/java/com/likeazusa2/dgmodules/ModContent.java
+++ b/src/main/java/com/likeazusa2/dgmodules/ModContent.java
@@ -84,6 +84,21 @@ public static final DeferredRegister<CreativeModeTab> CREATIVE_TABS =
         return CATACLYSM_ARROW_MODULE.get();
     }
 
+    // ===== Frame Breaker =====
+    public static final DeferredHolder<Item, FrameBreakerModuleItem> FRAME_BREAKER_MODULE_ITEM =
+            ITEMS.register("frame_breaker_module",
+                    () -> new FrameBreakerModuleItem(new Item.Properties(), ModContent::getFrameBreakerModule)
+            );
+
+    public static final DeferredHolder<Module<?>, FrameBreakerModule> FRAME_BREAKER_MODULE =
+            DG_MODULES.register("frame_breaker",
+                    () -> new FrameBreakerModule(FRAME_BREAKER_MODULE_ITEM.get())
+            );
+
+    private static Module<?> getFrameBreakerModule() {
+        return FRAME_BREAKER_MODULE.get();
+    }
+
     public static void init(IEventBus modBus) {
         ITEMS.register(modBus);
         BLOCKS.register(modBus);
@@ -332,6 +347,7 @@ public static final DeferredHolder<CreativeModeTab, CreativeModeTab> DG_MODULES_
                                 output.accept(COMPRESSED_CHAOTIC_DAMAGE_MODULE_ITEM.get());
                                 output.accept(COMPRESSED_CHAOTIC_SPEED_MODULE_ITEM.get());
                                 output.accept(CATACLYSM_ARROW_MODULE_ITEM.get());
+                                output.accept(FRAME_BREAKER_MODULE_ITEM.get());
                             })
                             .build()
             );

--- a/src/main/java/com/likeazusa2/dgmodules/logic/FrameBreakerEvents.java
+++ b/src/main/java/com/likeazusa2/dgmodules/logic/FrameBreakerEvents.java
@@ -1,0 +1,30 @@
+package com.likeazusa2.dgmodules.logic;
+
+import com.likeazusa2.dgmodules.DGModules;
+import com.likeazusa2.dgmodules.modules.FrameBreakerModuleEntity;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
+
+@EventBusSubscriber(modid = DGModules.MODID, bus = EventBusSubscriber.Bus.GAME)
+public class FrameBreakerEvents {
+
+    @SubscribeEvent
+    public static void onEntityJoinLevel(EntityJoinLevelEvent event) {
+        if (event.getLevel().isClientSide()) return;
+
+        Entity entity = event.getEntity();
+        if (!(entity instanceof Projectile projectile)) return;
+        if (!(projectile.getOwner() instanceof Player player)) return;
+
+        FrameBreakerModuleEntity module = FrameBreakerLogic.findHeldFrameBreaker(player);
+        if (module == null || !module.isEnabled()) return;
+
+        // 给投射物打标签，供 hurt mixin 在真正命中时判断是否清理目标无敌帧。
+        projectile.getPersistentData().putBoolean(FrameBreakerLogic.TAG_FRAME_BREAKER, true);
+        projectile.getPersistentData().putBoolean(FrameBreakerLogic.TAG_FRAME_BREAKER_AFFECT_PLAYERS, module.isAffectPlayers());
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/logic/FrameBreakerLogic.java
+++ b/src/main/java/com/likeazusa2/dgmodules/logic/FrameBreakerLogic.java
@@ -1,0 +1,52 @@
+package com.likeazusa2.dgmodules.logic;
+
+import com.brandon3055.draconicevolution.api.capability.DECapabilities;
+import com.brandon3055.draconicevolution.api.capability.ModuleHost;
+import com.likeazusa2.dgmodules.modules.FrameBreakerModuleEntity;
+import com.likeazusa2.dgmodules.modules.FrameBreakerModuleType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public class FrameBreakerLogic {
+
+    public static final String TAG_FRAME_BREAKER = "dg_frame_breaker";
+    public static final String TAG_FRAME_BREAKER_AFFECT_PLAYERS = "dg_frame_breaker_affect_players";
+
+    public static boolean hasFrameBreakerMelee(Player player, LivingEntity target) {
+        FrameBreakerModuleEntity main = findActiveModule(player.getMainHandItem());
+        if (main != null) {
+            return canAffect(main, target);
+        }
+
+        FrameBreakerModuleEntity off = findActiveModule(player.getOffhandItem());
+        return off != null && canAffect(off, target);
+    }
+
+    public static FrameBreakerModuleEntity findHeldFrameBreaker(Player player) {
+        FrameBreakerModuleEntity main = findActiveModule(player.getMainHandItem());
+        if (main != null) return main;
+        return findActiveModule(player.getOffhandItem());
+    }
+
+    private static boolean canAffect(FrameBreakerModuleEntity module, LivingEntity target) {
+        if (target instanceof Player && !module.isAffectPlayers()) {
+            return false;
+        }
+        return module.isEnabled();
+    }
+
+    private static FrameBreakerModuleEntity findActiveModule(ItemStack stack) {
+        if (stack.isEmpty()) return null;
+
+        try (ModuleHost host = DECapabilities.getHost(stack)) {
+            if (host == null) return null;
+            return host.getEntitiesByType(FrameBreakerModuleType.INSTANCE)
+                    .filter(ent -> ent instanceof FrameBreakerModuleEntity)
+                    .map(ent -> (FrameBreakerModuleEntity) ent)
+                    .filter(FrameBreakerModuleEntity::isEnabled)
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/mixin/frame/MixinFrameBreakerLivingHurt.java
+++ b/src/main/java/com/likeazusa2/dgmodules/mixin/frame/MixinFrameBreakerLivingHurt.java
@@ -1,0 +1,58 @@
+package com.likeazusa2.dgmodules.mixin.frame;
+
+import com.likeazusa2.dgmodules.logic.FrameBreakerLogic;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.Projectile;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+public abstract class MixinFrameBreakerLivingHurt {
+
+    @Inject(method = "hurt", at = @At("HEAD"))
+    private void dg$frameBreaker$clearIFrames(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        LivingEntity self = (LivingEntity) (Object) this;
+        if (self.level().isClientSide) return;
+
+        if (!shouldApplyFrameBreaker(source, self)) return;
+
+        // 关键逻辑：在 hurt() 最前面清空无敌帧相关计时，避免高频攻击被 i-frame 吞掉。
+        self.invulnerableTime = 0;
+        self.hurtTime = 0;
+        resetNoDamageTicksIfPresent(self);
+    }
+
+    private static boolean shouldApplyFrameBreaker(DamageSource source, LivingEntity target) {
+        Entity sourceEntity = source.getEntity();
+        if (sourceEntity instanceof Player player) {
+            // 近战：伤害来源玩家手持已启用 Frame Breaker 模块。
+            return FrameBreakerLogic.hasFrameBreakerMelee(player, target);
+        }
+
+        Entity direct = source.getDirectEntity();
+        if (direct instanceof Projectile projectile) {
+            if (!projectile.getPersistentData().getBoolean(FrameBreakerLogic.TAG_FRAME_BREAKER)) return false;
+
+            // 投射物支持 affect_players 配置：没开时不影响玩家，只对非玩家目标生效。
+            boolean affectPlayers = projectile.getPersistentData().getBoolean(FrameBreakerLogic.TAG_FRAME_BREAKER_AFFECT_PLAYERS);
+            return !(target instanceof Player) || affectPlayers;
+        }
+
+        return false;
+    }
+
+    private static void resetNoDamageTicksIfPresent(LivingEntity entity) {
+        try {
+            var field = LivingEntity.class.getDeclaredField("noDamageTicks");
+            field.setAccessible(true);
+            field.setInt(entity, 0);
+        } catch (Throwable ignored) {
+            // 1.21.1 某些映射可能没有 noDamageTicks，仅重置 invulnerableTime/hurtTime 也能覆盖主要 i-frame。
+        }
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModule.java
+++ b/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModule.java
@@ -1,0 +1,36 @@
+package com.likeazusa2.dgmodules.modules;
+
+import com.brandon3055.draconicevolution.api.modules.data.NoData;
+import com.brandon3055.draconicevolution.api.modules.lib.BaseModule;
+import com.brandon3055.draconicevolution.api.modules.lib.ModuleContext;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+
+import java.util.List;
+
+public class FrameBreakerModule extends BaseModule<NoData> {
+
+    private final Item item;
+
+    public FrameBreakerModule(Item item) {
+        super(FrameBreakerModuleType.INSTANCE, FrameBreakerModuleType.PROPERTIES);
+        this.item = item;
+    }
+
+    @Override
+    public Item getItem() {
+        return item;
+    }
+
+    @Override
+    public int maxInstallable() {
+        return 1;
+    }
+
+    @Override
+    public void addInformation(List<Component> info, ModuleContext context) {
+        super.addInformation(info, context);
+        info.add(Component.translatable("module.dgmodules.frame_breaker.desc").withStyle(ChatFormatting.GRAY));
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleEntity.java
+++ b/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleEntity.java
@@ -1,0 +1,189 @@
+package com.likeazusa2.dgmodules.modules;
+
+import com.brandon3055.draconicevolution.api.config.BooleanProperty;
+import com.brandon3055.draconicevolution.api.config.ConfigProperty;
+import com.brandon3055.draconicevolution.api.config.DecimalProperty;
+import com.brandon3055.draconicevolution.api.modules.Module;
+import com.brandon3055.draconicevolution.api.modules.data.NoData;
+import com.brandon3055.draconicevolution.api.modules.lib.ModuleContext;
+import com.brandon3055.draconicevolution.api.modules.lib.ModuleEntity;
+import com.brandon3055.draconicevolution.init.DEModules;
+import com.brandon3055.draconicevolution.init.ItemData;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+import java.util.Optional;
+
+public class FrameBreakerModuleEntity extends ModuleEntity<NoData> {
+
+    private Optional<BooleanProperty> enabled = Optional.empty();
+    private Optional<BooleanProperty> affectPlayers = Optional.empty();
+    private Optional<DecimalProperty> energyCostPerHit = Optional.empty();
+
+    public static final Codec<FrameBreakerModuleEntity> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+            DEModules.codec().fieldOf("module").forGetter(e -> (Module<?>) e.getModule()),
+            Codec.INT.fieldOf("gridx").forGetter(ModuleEntity::getGridX),
+            Codec.INT.fieldOf("gridy").forGetter(ModuleEntity::getGridY),
+            BooleanProperty.CODEC.optionalFieldOf("enabled").forGetter(e -> e.enabled.map(BooleanProperty::copy)),
+            BooleanProperty.CODEC.optionalFieldOf("affect_players").forGetter(e -> e.affectPlayers.map(BooleanProperty::copy)),
+            DecimalProperty.CODEC.optionalFieldOf("energy_cost_per_hit").forGetter(e -> e.energyCostPerHit.map(DecimalProperty::copy))
+    ).apply(inst, (m, x, y, en, ap, ec) -> {
+        FrameBreakerModuleEntity e = new FrameBreakerModuleEntity((Module<NoData>) m, x, y);
+        e.enabled = en;
+        e.affectPlayers = ap;
+        e.energyCostPerHit = ec;
+        e.attachListeners();
+        return e;
+    }));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, FrameBreakerModuleEntity> STREAM_CODEC =
+            StreamCodec.composite(
+                    DEModules.streamCodec(), e -> (Module<?>) e.getModule(),
+                    ByteBufCodecs.INT, ModuleEntity::getGridX,
+                    ByteBufCodecs.INT, ModuleEntity::getGridY,
+                    ByteBufCodecs.optional(BooleanProperty.STREAM_CODEC), e -> e.enabled.map(BooleanProperty::copy),
+                    ByteBufCodecs.optional(BooleanProperty.STREAM_CODEC), e -> e.affectPlayers.map(BooleanProperty::copy),
+                    ByteBufCodecs.optional(DecimalProperty.STREAM_CODEC), e -> e.energyCostPerHit.map(DecimalProperty::copy),
+                    (m, x, y, en, ap, ec) -> {
+                        FrameBreakerModuleEntity e = new FrameBreakerModuleEntity((Module<NoData>) m, x, y);
+                        e.enabled = en;
+                        e.affectPlayers = ap;
+                        e.energyCostPerHit = ec;
+                        e.attachListeners();
+                        return e;
+                    }
+            );
+
+    public FrameBreakerModuleEntity(Module<NoData> module) {
+        super(module);
+    }
+
+    public FrameBreakerModuleEntity(Module<NoData> module, int gridX, int gridY) {
+        super(module, gridX, gridY);
+    }
+
+    @Override
+    public ModuleEntity<?> copy() {
+        FrameBreakerModuleEntity e = new FrameBreakerModuleEntity((Module<NoData>) this.module, getGridX(), getGridY());
+        e.enabled = this.enabled.map(BooleanProperty::copy);
+        e.affectPlayers = this.affectPlayers.map(BooleanProperty::copy);
+        e.energyCostPerHit = this.energyCostPerHit.map(DecimalProperty::copy);
+        e.attachListeners();
+        return e;
+    }
+
+    private void attachListeners() {
+        enabled.ifPresent(p -> p.setChangeListener(stack -> {
+            stack.set(ItemData.BOOL_ITEM_PROP_1.get(), p.copy());
+            markDirty();
+        }));
+        affectPlayers.ifPresent(p -> p.setChangeListener(stack -> {
+            stack.set(ItemData.BOOL_ITEM_PROP_2.get(), p.copy());
+            markDirty();
+        }));
+        energyCostPerHit.ifPresent(p -> p.setChangeListener(stack -> {
+            stack.set(ItemData.DECIMAL_ITEM_PROP_1.get(), p.copy());
+            markDirty();
+        }));
+    }
+
+    @Override
+    public void getEntityProperties(List<ConfigProperty> properties) {
+        properties.add(getOrCreateEnabled());
+        properties.add(getOrCreateAffectPlayers());
+        properties.add(getOrCreateEnergyCostPerHit());
+    }
+
+    private BooleanProperty getOrCreateEnabled() {
+        return enabled.orElseGet(() -> {
+            BooleanProperty p = new BooleanProperty(
+                    "enabled",
+                    Component.translatable("dgmodules.module.frame_breaker.enabled"),
+                    true
+            );
+            p.setChangeListener(stack -> {
+                stack.set(ItemData.BOOL_ITEM_PROP_1.get(), p.copy());
+                markDirty();
+            });
+            enabled = Optional.of(p);
+            return p;
+        });
+    }
+
+    private BooleanProperty getOrCreateAffectPlayers() {
+        return affectPlayers.orElseGet(() -> {
+            BooleanProperty p = new BooleanProperty(
+                    "affect_players",
+                    Component.translatable("dgmodules.module.frame_breaker.affect_players"),
+                    false
+            );
+            p.setChangeListener(stack -> {
+                stack.set(ItemData.BOOL_ITEM_PROP_2.get(), p.copy());
+                markDirty();
+            });
+            affectPlayers = Optional.of(p);
+            return p;
+        });
+    }
+
+    private DecimalProperty getOrCreateEnergyCostPerHit() {
+        return energyCostPerHit.orElseGet(() -> {
+            DecimalProperty p = new DecimalProperty(
+                    "energy_cost_per_hit",
+                    Component.translatable("dgmodules.module.frame_breaker.energy_cost_per_hit"),
+                    0
+            ).range(0, 1_000_000_000);
+            p.setChangeListener(stack -> {
+                stack.set(ItemData.DECIMAL_ITEM_PROP_1.get(), p.copy());
+                markDirty();
+            });
+            energyCostPerHit = Optional.of(p);
+            return p;
+        });
+    }
+
+    @Override
+    public void saveEntityToStack(ItemStack stack, ModuleContext context) {
+        stack.set(ItemData.BOOL_ITEM_PROP_1.get(), getOrCreateEnabled().copy());
+        stack.set(ItemData.BOOL_ITEM_PROP_2.get(), getOrCreateAffectPlayers().copy());
+        stack.set(ItemData.DECIMAL_ITEM_PROP_1.get(), getOrCreateEnergyCostPerHit().copy());
+    }
+
+    @Override
+    public void loadEntityFromStack(ItemStack stack, ModuleContext context) {
+        BooleanProperty en = stack.get(ItemData.BOOL_ITEM_PROP_1.get());
+        BooleanProperty ap = stack.get(ItemData.BOOL_ITEM_PROP_2.get());
+        DecimalProperty ec = stack.get(ItemData.DECIMAL_ITEM_PROP_1.get());
+
+        enabled = Optional.empty();
+        affectPlayers = Optional.empty();
+        energyCostPerHit = Optional.empty();
+
+        if (en != null) enabled = Optional.of(en.copy());
+        if (ap != null) affectPlayers = Optional.of(ap.copy());
+        if (ec != null) energyCostPerHit = Optional.of(ec.copy());
+
+        getOrCreateEnabled();
+        getOrCreateAffectPlayers();
+        getOrCreateEnergyCostPerHit();
+        attachListeners();
+    }
+
+    public boolean isEnabled() {
+        return getOrCreateEnabled().getValue();
+    }
+
+    public boolean isAffectPlayers() {
+        return getOrCreateAffectPlayers().getValue();
+    }
+
+    public long getEnergyCostPerHit() {
+        return (long) getOrCreateEnergyCostPerHit().getValue();
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleItem.java
+++ b/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleItem.java
@@ -1,0 +1,15 @@
+package com.likeazusa2.dgmodules.modules;
+
+import com.brandon3055.draconicevolution.api.modules.Module;
+import com.brandon3055.draconicevolution.api.modules.data.NoData;
+import com.brandon3055.draconicevolution.api.modules.items.ModuleItem;
+import net.minecraft.world.item.Item;
+
+import java.util.function.Supplier;
+
+public class FrameBreakerModuleItem extends ModuleItem<NoData> {
+
+    public FrameBreakerModuleItem(Item.Properties props, Supplier<Module<?>> moduleSupplier) {
+        super(props, moduleSupplier);
+    }
+}

--- a/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleType.java
+++ b/src/main/java/com/likeazusa2/dgmodules/modules/FrameBreakerModuleType.java
@@ -1,0 +1,62 @@
+package com.likeazusa2.dgmodules.modules;
+
+import com.brandon3055.brandonscore.api.TechLevel;
+import com.brandon3055.draconicevolution.api.modules.Module;
+import com.brandon3055.draconicevolution.api.modules.ModuleCategory;
+import com.brandon3055.draconicevolution.api.modules.ModuleType;
+import com.brandon3055.draconicevolution.api.modules.data.ModuleProperties;
+import com.brandon3055.draconicevolution.api.modules.data.NoData;
+import com.brandon3055.draconicevolution.api.modules.lib.ModuleEntity;
+import com.mojang.serialization.Codec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class FrameBreakerModuleType implements ModuleType<NoData> {
+
+    public static final FrameBreakerModuleType INSTANCE = new FrameBreakerModuleType();
+
+    public static final ModuleProperties<NoData> PROPERTIES =
+            new ModuleProperties<>(TechLevel.DRACONIC, m -> new NoData());
+
+    private FrameBreakerModuleType() {}
+
+    @Override
+    public @NotNull Set<ModuleCategory> getCategories() {
+        return Set.of(ModuleCategory.MELEE_WEAPON, ModuleCategory.RANGED_WEAPON);
+    }
+
+    @Override
+    public int getDefaultWidth() {
+        return 2;
+    }
+
+    @Override
+    public int getDefaultHeight() {
+        return 2;
+    }
+
+    @Override
+    public String getName() {
+        return "frame_breaker";
+    }
+
+    @Override
+    public ModuleEntity<NoData> createEntity(Module<NoData> module) {
+        return new FrameBreakerModuleEntity(module);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Codec<ModuleEntity<?>> entityCodec() {
+        return (Codec<ModuleEntity<?>>) (Codec<?>) FrameBreakerModuleEntity.CODEC;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public StreamCodec<RegistryFriendlyByteBuf, ModuleEntity<?>> entityStreamCodec() {
+        return (StreamCodec<RegistryFriendlyByteBuf, ModuleEntity<?>>) (StreamCodec<?, ?>) FrameBreakerModuleEntity.STREAM_CODEC;
+    }
+}

--- a/src/main/resources/assets/dgmodules/lang/en_us.json
+++ b/src/main/resources/assets/dgmodules/lang/en_us.json
@@ -45,13 +45,11 @@
   "key.dgmodules.phase_shield_toggle": "Toggle Phase Shield",
   "hud.dgmodules.phase_shield.on": "Phase Shield enabled - it won't last long, get out of danger!",
   "hud.dgmodules.phase_shield.time": "Estimated time remaining: %s s",
-
   "item.dgmodules.shield_control_booster_module": "Shield Control Booster Module",
-  "module_type.draconicevolution.shield_control_booster.name":"Shield Control Booster",
+  "module_type.draconicevolution.shield_control_booster.name": "Shield Control Booster",
   "module.dgmodules.shield_control_booster.line1": "• Reduce shield regeneration cooldown time",
   "module.dgmodules.shield_control_booster.line2": "• Enhance the overall performance of the shield",
   "module_type.draconicevolution.phase_shield.name": "Phase Shield",
-
   "item.dgmodules.cataclysm_arrow_module": "Cataclysm Arrow Module",
   "module_type.draconicevolution.cataclysm_arrow.name": "Cataclysm Arrow",
   "module.dgmodules.cataclysm_arrow.desc": "Arrows trigger a violent cataclysm on impact, dealing devastating explosion damage.",
@@ -62,5 +60,10 @@
   "item_prop.draconicevolution.high_frequency_pierce": "Enable high-frequency armor-piercing pulses",
   "item_prop.draconicevolution.summon_fireball": "Enable Cataclysm",
   "death.attack.cataclysm_pierce": "%1$s was shredded by high-frequency cataclysm pulses",
-  "death.attack.cataclysm_pierce.player": "%1$s was shredded by %2$s's cataclysm pulses"
+  "death.attack.cataclysm_pierce.player": "%1$s was shredded by %2$s's cataclysm pulses",
+  "item.dgmodules.frame_breaker_module": "Frame Breaker Module",
+  "module_type.draconicevolution.frame_breaker.name": "Frame Breaker",
+  "module.dgmodules.frame_breaker.desc": "Clears target i-frames so high-frequency hits can apply every time.",
+  "item_prop.draconicevolution.affect_players": "Affect Players",
+  "item_prop.draconicevolution.energy_cost_per_hit": "Energy Cost Per Hit"
 }

--- a/src/main/resources/assets/dgmodules/lang/zh_cn.json
+++ b/src/main/resources/assets/dgmodules/lang/zh_cn.json
@@ -3,49 +3,40 @@
   "module_type.draconicevolution.chaos_laser.name": "混沌龙激光",
   "key.dgmodules.chaos_laser": "混沌激光",
   "key.categories.dgmodules": "DGModules",
-
   "item.dgmodules.dragon_guard_module": "龙之守护模块",
   "module_type.draconicevolution.dragon_guard.name": "龙之守护",
   "module.dgmodules.dragon_guard.desc": "消耗大量能量，抵御一次致命打击。",
   "tooltip.dgmodules.dragon_guard.cost": "触发时消耗指定量OP",
   "hud.dgmodules.dragon_guard.warn": "警告，强大的打击",
-
   "itemGroup.dgmodules": "DG模块",
-
   "item.dgmodules.draconic_hp_damage_module": "神龙生命削减模块",
   "item.dgmodules.wyvern_hp_damage_module": "双足飞龙生命削减模块",
   "item.dgmodules.chaotic_hp_damage_module": "混沌生命削减模块",
   "module_type.draconicevolution.current_hp_damage.name": "生命削减",
   "tooltip.dgmodules.hp_damage.energy": "每 1 点额外伤害消耗 2000 OP",
   "tooltip.dgmodules.hp_cut.total": "生命削减总倍率：%s%%(当前生命值)",
-
   "module_type.draconicevolution.flight_tuner.name": "飞行调整",
   "item.dgmodules.flight_tuner_module": "飞行调整模块",
   "item_prop.draconicevolution.speed_mul": "综合飞行速度",
   "item_prop.draconicevolution.no_inertia": "禁用惯性",
-
   "item.dgmodules.negative_effect_immunity_module": "负面效果免疫模块",
   "module_type.draconicevolution.negative_effect_immunity.name": "负面效果免疫",
   "module.dgmodules.negative_effect_immunity.desc": "免疫所有负面药水效果",
-
   "item.dgmodules.shield_control_booster_module": "护盾控制强化模块",
   "module_type.draconicevolution.shield_control_booster.name": "护盾强化",
   "module.dgmodules.shield_control_booster.line1": "• 缩短护盾恢复冷却时间",
   "module.dgmodules.shield_control_booster.line2": "• 强化护盾整体表现",
-
   "item.dgmodules.compressed_chaotic_energy_module": "压缩混沌能量模块",
   "item.dgmodules.compressed_chaotic_shield_recovery_module": "压缩混沌护盾恢复模块",
   "item.dgmodules.compressed_chaotic_large_shield_capacity_module": "压缩混沌大型护盾容量模块",
   "item.dgmodules.compressed_chaotic_damage_module": "压缩混沌伤害模块",
   "item.dgmodules.compressed_chaotic_speed_module": "压缩混沌速度模块",
-
   "module.dgmodules.compressed_chaotic_energy.desc": "将3个混沌能量模块压缩为2×1结构，提供更高的能量存储与传输。",
   "module.dgmodules.compressed_chaotic_shield_recovery.desc": "将3个混沌护盾恢复模块压缩为2×1结构，大幅提升护盾充能速度。",
   "module.dgmodules.compressed_chaotic_large_shield_capacity.desc": "将3个混沌大型护盾容量模块压缩为2×2结构，大幅提升护盾容量上限。",
   "module.dgmodules.compressed_chaotic_damage.desc": "将3个混沌伤害模块压缩为2×1结构，显著提升武器伤害。",
   "module.dgmodules.compressed_chaotic_speed.desc": "将3个混沌速度模块压缩为2×1结构，显著提升工具/武器速度。",
   "block.dgmodules.dont_ignite": "不要点燃",
-
   "key.dgmodules.phase_shield": "相位护盾",
   "module.dgmodules.phase_shield.desc": "按下按键进入相位状态：取消所有攻击并免疫绝大部分伤害，持续消耗巨额 OP。",
   "tooltip.dgmodules.phase_shield.require": "前置：护胸必须安装“护盾控制强化模块”。",
@@ -56,7 +47,6 @@
   "key.dgmodules.phase_shield_toggle": "切换相位护盾",
   "hud.dgmodules.phase_shield.on": "相位护盾已开启，但它持续不了多久，请迅速远离危险！",
   "hud.dgmodules.phase_shield.time": "预计剩余时间: %s 秒",
-
   "item.dgmodules.cataclysm_arrow_module": "天灾箭矢模块",
   "module_type.draconicevolution.cataclysm_arrow.name": "天灾箭矢",
   "module.dgmodules.cataclysm_arrow.desc": "箭矢命中后引发剧烈天灾爆破，造成高强度爆炸伤害。",
@@ -67,5 +57,10 @@
   "item_prop.draconicevolution.high_frequency_pierce": "启用高频穿甲脉冲",
   "item_prop.draconicevolution.summon_fireball": "启动天罚",
   "death.attack.cataclysm_pierce": "%1$s 被天灾高频脉冲撕裂",
-  "death.attack.cataclysm_pierce.player": "%1$s 被 %2$s 的天灾高频脉冲撕裂"
+  "death.attack.cataclysm_pierce.player": "%1$s 被 %2$s 的天灾高频脉冲撕裂",
+  "item.dgmodules.frame_breaker_module": "破帧模块",
+  "module_type.draconicevolution.frame_breaker.name": "破帧",
+  "module.dgmodules.frame_breaker.desc": "在受击判定前清除目标无敌帧，使高频攻击每次都能结算伤害。",
+  "item_prop.draconicevolution.affect_players": "影响玩家",
+  "item_prop.draconicevolution.energy_cost_per_hit": "每次命中能耗"
 }

--- a/src/main/resources/assets/dgmodules/models/item/frame_breaker_module.json
+++ b/src/main/resources/assets/dgmodules/models/item/frame_breaker_module.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "dgmodules:item/frame_breaker_module"
+  }
+}

--- a/src/main/resources/mixins/dgmodules.json
+++ b/src/main/resources/mixins/dgmodules.json
@@ -7,6 +7,8 @@
     "MixinShieldControlEntity",
     "MixinModuleEntityHostAccess",
 
+    "frame.MixinFrameBreakerLivingHurt",
+
     "phase.MixinPhaseShieldHurt",
     "phase.MixinPhaseShieldBlockDamageLeftClickItem",
     "phase.MixinPhaseShieldPickable"


### PR DESCRIPTION
### Motivation
- 解决高频自动点击/穿频攻击在目标无敌帧（i-frames）期间被吞掉的问题，使每次命中都能生效（覆盖近战与远程）。
- 需要与现有 DE 模块系统一致地暴露 GUI 配置并支持武器/投射物标记，以便按配置生效并可消耗能量。 

### Description
- 新增完整模块实现：`ModuleType/ModuleItem/Module/ModuleEntity`（Draconic、2x2），文件包括 `FrameBreakerModuleType`, `FrameBreakerModuleItem`, `FrameBreakerModule`, `FrameBreakerModuleEntity`，并在 `ModContent` 中注册模块与物品并加入创意界面。 
- GUI 配置项实现：`enabled`（默认 true）、`affect_players`（默认 false）、`energy_cost_per_hit`（默认 0），并在 `FrameBreakerModuleEntity` 中实现保存/加载与监听；相关文本已加入 `en_us` 与 `zh_cn`，并新增物品模型资源。 
- 攻击标记与判定：在 `EntityJoinLevelEvent`（`FrameBreakerEvents`）里为由持有启用破帧模块的玩家发射的 `Projectile` 写入持久 NBT 标签 `dg_frame_breaker=true` 与 `dg_frame_breaker_affect_players=<bool>`；近战通过检查 `DamageSource.getEntity()` 是否为玩家并检测玩家主/副手持有启用模块来判定。 
- 核心行为（Mixin）：新增 `MixinFrameBreakerLivingHurt`，在 `LivingEntity.hurt(DamageSource,float)` 的 `HEAD` 注入，若命中来源满足破帧条件则在任何无敌判定前清零 `invulnerableTime` 与 `hurtTime` 并尝试通过反射清零 `noDamageTicks`（代码内有中文注释解释为何在 HEAD 清理及反射兼容细节），不改变击退或爆炸相关逻辑；同时已在 `mixins/dgmodules.json` 注册该 mixin。 

### Testing
- 进行了编译尝试：运行 `./gradlew compileJava`，构建失败因为当前环境缺少 Java 21 toolchain（Gradle 报错无法找到 Java 21），因此未能在此环境完成编译验证（失败）。
- 已检查并提交变更：`git commit` 成功（提交信息：Add Draconic frame breaker module with hurt mixin support），并通过 `git status` 确认工作区已提交（成功）。
- 代码内关键位置包含中文注释以说明实现要点及兼容性考虑，便于后续审阅与运行时测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698b42d15c788329b83207ea99cf0288)